### PR TITLE
Updates the iso3166 package to the league package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ bin
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# phpstorm
+.idea

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.4",
         "omnipay/common": "~2.3",
-        "league/iso3166": "2.x-dev"
+        "league/iso3166": "~1.0.1"
     },
     "require-dev": {
         "omnipay/tests": "~2.0"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.4",
         "omnipay/common": "~2.3",
-        "alcohol/iso3166": "~2.0"
+        "league/iso3166": "2.x-dev"
     },
     "require-dev": {
         "omnipay/tests": "~2.0"

--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -2,8 +2,12 @@
 
 namespace Omnipay\FirstAtlanticCommerce;
 
+use League\ISO3166\ISO3166;
 use Omnipay\Common\CreditCard as BaseCreditCard;
 use Omnipay\Common\Exception\InvalidCreditCardException;
+use Omnipay\Common\Exception\InvalidRequestException;
+use Omnipay\Common\Helper;
+
 
 class CreditCard extends BaseCreditCard
 {
@@ -65,5 +69,37 @@ class CreditCard extends BaseCreditCard
                 throw new InvalidCreditCardException('Card CVV should have 3 to 4 digits');
             }
         }
+    }
+
+    /**
+     * Returns the country as the numeric ISO 3166-1 code
+     *
+     * @throws InvalidRequestException
+     *
+     * @return int ISO 3166-1 numeric country
+     */
+    public function getNumericCountry()
+    {
+        $country = $this->getCountry();
+
+        if ( !is_null($country) && !is_numeric($country) )
+        {
+            $iso3166 = new ISO3166();
+
+            if ( strlen($country) == 2 )
+            {
+                $country = $iso3166->alpha2($country)['numeric'];
+            }
+            elseif ( strlen($country) == 3 )
+            {
+                $country = $iso3166->alpha3($country)['numeric'];
+            }
+            else
+            {
+                throw new InvalidRequestException("The country parameter must be ISO 3166-1 numeric, aplha2 or alpha3.");
+            }
+        }
+
+        return $country;
     }
 }

--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -88,11 +88,11 @@ class CreditCard extends BaseCreditCard
 
             if ( strlen($country) == 2 )
             {
-                $country = $iso3166->alpha2($country)['numeric'];
+                $country = $iso3166->getByAlpha2($country)['numeric'];
             }
             elseif ( strlen($country) == 3 )
             {
-                $country = $iso3166->alpha3($country)['numeric'];
+                $country = $iso3166->getByAlpha3($country)['numeric'];
             }
             else
             {

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\FirstAtlanticCommerce\Message;
 
 use Omnipay\Common\Message\AbstractRequest as BaseAbstractRequest;
+use Omnipay\Common\Message\ResponseInterface;
 use Omnipay\FirstAtlanticCommerce\CreditCard;
 use Omnipay\FirstAtlanticCommerce\ParameterTrait;
 use SimpleXMLElement;
@@ -132,7 +133,7 @@ abstract class AbstractRequest extends BaseAbstractRequest
      *
      * @param CreditCard $value
      *
-     * @return AbstractRequest Provides a fluent interface
+     * @return \Omnipay\Common\Message\AbstractRequest Provides a fluent interface
      */
     public function setCard($value)
     {
@@ -142,5 +143,15 @@ abstract class AbstractRequest extends BaseAbstractRequest
         }
 
         return $this->setParameter('card', $value);
+    }
+
+    /**
+     * Get the card.
+     *
+     * @return CreditCard
+     */
+    public function getCard()
+    {
+        return $this->getParameter('card');
     }
 }

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -2,9 +2,7 @@
 
 namespace Omnipay\FirstAtlanticCommerce\Message;
 
-use Alcohol\ISO3166;
 use Omnipay\Common\Exception\InvalidRequestException;
-use Omnipay\FirstAtlanticCommerce\Message\AbstractRequest;
 
 /**
  * FACPG2 Authorize Request
@@ -105,7 +103,7 @@ class AuthorizeRequest extends AbstractRequest
             'BillToFirstName'   => $this->getCard()->getFirstName(),
             'BillToLastName'    => $this->getCard()->getLastName(),
             'BillToCity'        => $this->getCard()->getCity(),
-            'BillToCountry'     => $this->formatCountry(),
+            'BillToCountry'     => $this->getCard()->getNumericCountry(),
             'BillToEmail'       => $this->getCard()->getEmail(),
             'BillToTelephone'   => $this->getCard()->getPhone(),
             'BillToFax'         => $this->getCard()->getFax()
@@ -127,41 +125,9 @@ class AuthorizeRequest extends AbstractRequest
     }
 
     /**
-     * Returns the country as the numeric ISO 3166-1 code
-     *
-     * @throws Omnipay\Common\Exception\InvalidRequestException
-     *
-     * @return int ISO 3166-1 numeric country
-     */
-    protected function formatCountry()
-    {
-        $country = $this->getCard()->getCountry();
-
-        if ( !is_null($country) && !is_numeric($country) )
-        {
-            $iso3166 = new ISO3166;
-
-            if ( strlen($country) == 2 )
-            {
-                $country = $iso3166->getByAlpha2($country)['numeric'];
-            }
-            elseif ( strlen($country) == 3 )
-            {
-                $country = $iso3166->getByAlpha3($country)['numeric'];
-            }
-            else
-            {
-                throw new InvalidRequestException("The country parameter must be ISO 3166-1 numeric, aplha2 or alpha3.");
-            }
-        }
-
-        return $country;
-    }
-
-    /**
      * Returns the billing state if its a US abbreviation or throws an exception
      *
-     * @throws Omnipay\Common\Exception\InvalidRequestException
+     * @throws InvalidRequestException
      *
      * @return string State abbreviation
      */
@@ -181,7 +147,7 @@ class AuthorizeRequest extends AbstractRequest
      * Returns the postal code sanitizing dashes and spaces and throws exceptions with other
      * non-alphanumeric characters
      *
-     * @throws Omnipay\Common\Exception\InvalidRequestException
+     * @throws InvalidRequestException
      *
      * @return string Postal code
      */

--- a/tests/AuthorizeTest.php
+++ b/tests/AuthorizeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace tests;
+
+
+use Omnipay\FirstAtlanticCommerce\Gateway;
+use Omnipay\Tests\GatewayTestCase;
+
+class AuthorizeTest extends GatewayTestCase
+{
+
+    /** @var  Gateway */
+    protected $gateway;
+
+    /**
+     * Setup the gateway to be used for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->gateway = new Gateway($this->getHttpClient(), $this->getHttpRequest());
+        $this->gateway->setMerchantId('123');
+        $this->gateway->setMerchantPassword('abc123');
+    }
+
+    /**
+     * Test the country formatting functionality
+     */
+    public function testFormatCountry()
+    {
+        //Alpha2
+        $card = $this->getValidCard();
+        $requestData = $this->getRequestData($card);
+        $this->assertEquals(840, $requestData['BillingDetails']['BillToCountry']);
+
+        //number
+        $card['billingCountry'] = 840;
+        $requestData = $this->getRequestData($card);
+        $this->assertEquals(840, $requestData['BillingDetails']['BillToCountry']);
+
+        //Alpha3
+        $card['billingCountry'] = 'USA';
+        $requestData = $this->getRequestData($card);
+        $this->assertEquals(840, $requestData['BillingDetails']['BillToCountry']);
+    }
+
+    /**
+     * @param $card
+     *
+     * @return array
+     */
+    private function getRequestData($card)
+    {
+        $request = $this->gateway->authorize([
+            'amount' => '10.00',
+            'currency' => 'USD',
+            'transactionId' => uniqid(),
+            'card' => $card
+        ]);
+        $requestData = $request->getData();
+        return $requestData;
+    }
+
+}


### PR DESCRIPTION
The alcohol/iso3166 is listed as abandoned and is recommended that league/iso3166 is used instead. This pull request updates the package being used. I also moved the formatCountry function into the CreditCard class since it is specifically manipulating CreditCard data and this would allow that function to be used anywhere the CreditCard class is used.